### PR TITLE
ci: fix release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.MACHINE_USER_TOKEN }}
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v2


### PR DESCRIPTION
## Changes

Run the release workflow as default GitHub bot to fix a permission issue.